### PR TITLE
Default new sub requests for "today", as per request

### DIFF
--- a/src/SubNotify.FrontEnd/Components/Pages/NotifySpecific.razor
+++ b/src/SubNotify.FrontEnd/Components/Pages/NotifySpecific.razor
@@ -65,8 +65,8 @@
 
             // Build out defaults for new event
             newSubEvent = new SubEvent() {
-                StartDate = DateTime.Today.AddDays(1),
-                EndDate = DateTime.Today.AddDays(1),
+                StartDate = DateTime.Today,
+                EndDate = DateTime.Today,
                 SubNeedsAccessToEmail = true,
                 RequestedTimestampUTC = DateTime.Now,
                 SchoolGUID = selectedSchool.Id,


### PR DESCRIPTION
"Today" referring to the day that the form was filled out, as opposed to the next day (tomorrow), which was the previous setting.