### PR TITLE
See if this fixes the time conversion issue...

### DIFF
--- a/src/SubNotify.Notifier/Program.cs
+++ b/src/SubNotify.Notifier/Program.cs
@@ -82,14 +82,14 @@ namespace SubNotify.Notifier
 
 
                 // Window to look for events
-                DateTime startOfTodayLocalTime = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 0,0,0, DateTimeKind.Unspecified);
-                DateTime endOfTodayLocalTime = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 23, 59, 59, DateTimeKind.Unspecified);
+                DateTime startOfTodayLocalTime = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 0,0,0, DateTimeKind.Local);
+                DateTime endOfTodayLocalTime = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 23, 59, 59, DateTimeKind.Local);
                 DateTime startOfTodayConvertedToUTC = TimeZoneInfo.ConvertTime(startOfTodayLocalTime, TimeZoneInfo.Utc);
                 DateTime endOfTodayConvertedToUTC = TimeZoneInfo.ConvertTime(endOfTodayLocalTime, TimeZoneInfo.Utc);
                 
                 // Window to notify
-                DateTime startNotificationWindowLocal = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 5,0,0, DateTimeKind.Unspecified);
-                DateTime endNotificationWindowLocal = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 17, 0, 0, DateTimeKind.Unspecified);
+                DateTime startNotificationWindowLocal = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 5,0,0, DateTimeKind.Local);
+                DateTime endNotificationWindowLocal = new DateTime(currentLocalTime.Year, currentLocalTime.Month, currentLocalTime.Day, 17, 0, 0, DateTimeKind.Local);
                 DateTime startNotificationWindowUTC = TimeZoneInfo.ConvertTime(startNotificationWindowLocal, TimeZoneInfo.Utc);
                 DateTime endNotificationWindowUTC = TimeZoneInfo.ConvertTime(endNotificationWindowLocal, TimeZoneInfo.Utc);
 


### PR DESCRIPTION
Specify that the time is local instead of "unspecified". I thought I understood what unspecified meant based on the MS documentation, but perhaps I misunderstood.