### PR TITLE
Fix bug where a multi-day events get ignored due to incorrect logic.

### DIFF
--- a/src/SubNotify.Notifier/Program.cs
+++ b/src/SubNotify.Notifier/Program.cs
@@ -97,7 +97,7 @@ namespace SubNotify.Notifier
                 List<SubEvent> subEvents = subEventRepo.Find(x =>
                     (x.IsCancelled != true) &&
                     (x.StartDate >= startOfTodayConvertedToUTC) &&
-                    (x.EndDate <= endOfTodayConvertedToUTC) &&
+                    (x.StartDate <= endOfTodayConvertedToUTC) &&
                     (
                         (x.TicketCreated_Onboard == false) ||
                         (x.TicketCreated_Offboard == false)


### PR DESCRIPTION
We only care about the "start" date, not if the event is constrained within a single calendar day. This should fix it to be what I originally intended the logic to be - checking for any events that _start_ within a single calendar day regardless of when they end.