### PR TITLE
Sanity checks on start and end dates, and add some warnings

### DIFF
--- a/src/SubNotify.Core/SubEvent.cs
+++ b/src/SubNotify.Core/SubEvent.cs
@@ -4,11 +4,37 @@ public class SubEvent : IGUIDable
 {
     public Guid Id { get; set; }
     public DateTime RequestedTimestampUTC { get; set; }
-    public DateTime StartDate { get; set; }
-    public DateTime EndDate { get; set; }
-    public string RequestorOID { get;set; }
-    public string RequestorName { get; set; }    
-    public string RequestorEmail { get; set; }    
+
+    private DateTime _startDate;
+    public DateTime StartDate
+    {
+        get => _startDate;
+        set
+        {
+            this._startDate = value;
+            if (this._startDate > this._endDate)
+            {
+                this._endDate = this._startDate;
+            }
+        }
+    }
+
+    private DateTime _endDate;
+    public DateTime EndDate
+    {
+        get => _endDate;
+        set
+        {
+            this._endDate = value;
+            if (this._endDate < this._startDate)
+            {
+                this._startDate = this._endDate;
+            }
+        }
+    }
+    public string RequestorOID { get; set; }
+    public string RequestorName { get; set; }
+    public string RequestorEmail { get; set; }
     public string SubstituteFor { get; set; }
     public Guid SubGUID { get; set; }
     public string SubName { get; set; }
@@ -18,11 +44,12 @@ public class SubEvent : IGUIDable
     public bool TicketCreated_Onboard { get; set; } = false;
     public bool TicketCreated_Offboard { get; set; } = false;
     public DateTime LastNotifyTimestamp { get; set; }
-    public string Notes { get;set ;}
-    public bool IsCancelled { get; set; } 
+    public string Notes { get; set; }
+    public bool IsCancelled { get; set; }
 
     public override string ToString()
     {
+
         string returnMe = @"
             { 
                 Id: " + this.Id.ToString() + @" 

--- a/src/SubNotify.FrontEnd/Components/Pages/Home.razor
+++ b/src/SubNotify.FrontEnd/Components/Pages/Home.razor
@@ -90,6 +90,7 @@
             </div>
             <br/>
 
+
             @foreach(Guid schoolGuid in userPermissions.SchoolGUIDs)
             {
                 @if (schoolsByID.ContainsKey(schoolGuid)) {
@@ -104,6 +105,8 @@
                     {
                         <h2>@(thisSchool.Name)</h2>
 
+                        <div style="font-weight: bold; padding: 7px; border-radius: 5px; border: 2px solid firebrick; color: firebrick;">⚠️ REMINDER:  If you no longer need a request that has been created, please click the CANCEL button.</div>
+                        <br/>
                         <SubEventTable Events="@(combined)" />
                         <br/><br/><br/>
                     }

--- a/src/SubNotify.FrontEnd/Components/Pages/NotifySpecific.razor
+++ b/src/SubNotify.FrontEnd/Components/Pages/NotifySpecific.razor
@@ -286,7 +286,7 @@
                 @if(activeSubs.Count > 0)
                 {
                     <br/><br/><br/><br/>
-                    <h2>Active subsitutes for @(selectedSchool.Name)</h2>
+                    <h2>Active subsitutes for @(selectedSchool.Name)</h2>                    
                     <SubEventTable Events="@(activeSubs)" />
                 }
 
@@ -294,6 +294,8 @@
                 {
                     <br/><br/><br/><br/>
                     <h2>Upcoming substitutes for @(selectedSchool.Name)</h2>
+                    <div style="font-weight: bold; padding: 7px; border-radius: 5px; border: 2px solid firebrick; color: firebrick;">⚠️ REMINDER:  If you no longer need a request that has been created, please click the CANCEL button.</div>
+                    <br/>
                     <SubEventTable Events="@(upcomingSubs)" />
                 }
 

--- a/src/SubNotify.FrontEnd/Components/SubEventTable.razor
+++ b/src/SubNotify.FrontEnd/Components/SubEventTable.razor
@@ -55,15 +55,15 @@
         <td style="padding: 5px;border-bottom: 1px solid #C0C0C0; @cancelledCSS">@(subEvent.SubName)</td>
         <td style="padding: 5px;border-bottom: 1px solid #C0C0C0; @cancelledCSS;text-align: center;">@(subEvent.SubNeedsAccessToEmail ? "✅" : "")</td>
         <td style="padding: 5px;border-bottom: 1px solid #C0C0C0;">
-            <a href="/Event/@(subEvent.Id)">Details</a>
+            <a style="text-decoration: none;" href="/Event/@(subEvent.Id)">Details</a>
         </td>
         <td style="padding: 5px;border-bottom: 1px solid #C0C0C0;text-align: center;">
             @if(subEvent.IsCancelled) 
             {
                 <b style="color: red;">CANCELLED</b>
-                <button type="button" @onclick="() => OnClick_UnCancelEvent(subEvent)" style="border: 0" class="btn btn-link">Un-Cancel</button>
+                <button type="button" @onclick="() => OnClick_UnCancelEvent(subEvent)" style="border: 0; color: green; text-decoration: none;" class="btn btn-link">Un-Cancel</button>
             } else {
-                <button type="button" @onclick="() => OnClick_CancelEvent(subEvent)" style="border: 0" class="btn btn-link">Cancel</button>
+                <button type="button" @onclick="() => OnClick_CancelEvent(subEvent)" style="border: 0; color: firebrick; text-decoration: none;" class="btn btn-link">Cancel</button>
             }
         </td>        
     </tr>


### PR DESCRIPTION
- If the start date is after the end date, set the start date to the end date
- If the end date is before the start date, set the start date to match the end date
- Add warnings to cancel submissions if they are no longer needed, and update the styles of the cancel and uncancel buttons to make them more obvious and separate from other controls on the page.